### PR TITLE
Move ID injection from the generator to the parser

### DIFF
--- a/addon/generator.js
+++ b/addon/generator.js
@@ -1,5 +1,3 @@
-import { Field } from 'graphql-adapter/types';
-
 export default function Generator() {}
 
 Generator.openingToken = '{';
@@ -26,9 +24,8 @@ Generator.closeOperation = function(acc) {
   return acc + this.closingToken;
 };
 
-Generator.generateField = function(field, injectId) {
+Generator.generateField = function(field) {
   let acc = this.separatorToken + field.name;
-  injectId = injectId === false ? false : true;
 
   if (field.argumentSet.length > 0) {
     acc = this.generateArgumentSet(field.argumentSet, acc);
@@ -37,21 +34,16 @@ Generator.generateField = function(field, injectId) {
   acc = acc + this.separatorToken;
 
   if (field.selectionSet.length > 0) {
-    acc = this.generateSelectionSet(field.selectionSet, acc, injectId);
+    acc = this.generateSelectionSet(field.selectionSet, acc);
   }
 
   return acc;
 };
 
-Generator.generateSelectionSet = function(set, acc, injectId) {
+Generator.generateSelectionSet = function(set, acc) {
   acc = acc + this.openingToken;
 
-  if (injectId === true) {
-    acc = acc + this.generateField(new Field('id'), acc);
-  }
-
   set.forEach((field) => {
-    if(field.name === 'id') { return; }
     acc = acc + this.generateField(field, acc);
   });
 

--- a/addon/parser.js
+++ b/addon/parser.js
@@ -5,6 +5,8 @@ export default function Parser() {}
 Parser.parse = function(model, store, operation, rootField) {
   this.store = store;
 
+  rootField.selectionSet.push(new Type.Field('id'));
+
   model.eachAttribute((attr) => {
     let field = new Type.Field(attr);
 
@@ -13,7 +15,7 @@ Parser.parse = function(model, store, operation, rootField) {
 
   model.eachRelationship((rel) => {
     let relModel = this.store.modelFor(rel);
-    let field = new Type.Field(rel);
+    let field = new Type.Field(rel, new Type.ArgumentSet(), new Type.SelectionSet(new Type.Field('id')));
 
     relModel.eachAttribute(function(attr) {
       let relField = new Type.Field(attr);
@@ -25,5 +27,6 @@ Parser.parse = function(model, store, operation, rootField) {
   });
 
   operation.selectionSet.push(rootField);
+
   return operation;
 };

--- a/tests/unit/parser-test.js
+++ b/tests/unit/parser-test.js
@@ -34,25 +34,44 @@ test('root field is generated in the selection set', function(assert){
   assert.equal(rootField.name, 'projects');
 });
 
-test('there are as many elements in the selection set as there are top level fields', function(assert){
+test('there are as many elements in the selection set as there are top level fields (plus the id field)', function(assert){
   let rootField = this.parseTree.selectionSet[0];
   let projectsSelectionSet = rootField.selectionSet;
 
-  assert.equal(projectsSelectionSet.length, 3);
+  assert.equal(projectsSelectionSet.length, 4);
 });
 
 test('nested fields are generated in the root field selection set', function(assert){
   let rootField = this.parseTree.selectionSet[0];
   let projectsSelectionSet = rootField.selectionSet;
-  let expectedStatusField = projectsSelectionSet[0];
+
+  let expectedIdField = projectsSelectionSet[0];
+  assert.equal(expectedIdField instanceof Type.Field, true);
+  assert.equal(expectedIdField.name, 'id');
+
+  let expectedStatusField = projectsSelectionSet[1];
   assert.equal(expectedStatusField instanceof Type.Field, true);
   assert.equal(expectedStatusField.name, 'status');
 
-  let expectedNameField = projectsSelectionSet[1];
+  let expectedNameField = projectsSelectionSet[2];
   assert.equal(expectedNameField instanceof Type.Field, true);
   assert.equal(expectedNameField.name, 'name');
 
-  let expectedAuthorField = projectsSelectionSet[2];
-  assert.equal(expectedAuthorField instanceof Type.Field, true);
-  assert.equal(expectedAuthorField.name, 'user');
+  let expectedUserField = projectsSelectionSet[3];
+  assert.equal(expectedUserField instanceof Type.Field, true);
+  assert.equal(expectedUserField.name, 'user');
+});
+
+test('belongsTo id injection', function(assert) {
+  let rootField = this.parseTree.selectionSet[0];
+  let projectsSelectionSet = rootField.selectionSet;
+  let expectedUserField = projectsSelectionSet[3];
+
+  let expectedUserIdField = expectedUserField.selectionSet[0];
+  assert.equal(expectedUserIdField instanceof Type.Field, true);
+  assert.equal(expectedUserIdField.name, 'id');
+
+  let expectedUserNameField = expectedUserField.selectionSet[1];
+  assert.equal(expectedUserNameField instanceof Type.Field, true);
+  assert.equal(expectedUserNameField.name, 'name');
 });


### PR DESCRIPTION
It makes sense to inject this when creating the intermediary code (in
the parser). Generally is cleaner code as well. Was doing some weird
things in the generator.
