### PR TITLE
Add support for hasMany associations

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -313,7 +313,6 @@ export default DS.Adapter.extend({
       'dataType': 'json',
       'data': data,
       'type': this.httpMethod,
-      'type': 'GET',
       'context': this
     };
 

--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -4,6 +4,7 @@ import Compiler from './compiler';
 
 export default DS.Adapter.extend({
   endpoint: null,
+  httpMethod: 'GET',
   param: 'query',
   defaultSerializer: '-graphql',
   coalesceFindRequests: false,
@@ -12,7 +13,7 @@ export default DS.Adapter.extend({
     Called by the store in order to fetch the JSON for a given
     type and ID.
 
-    The `findRecord` method makes an Ajax (HTTP GET) request to the GraphQL
+    The `findRecord` method makes an Ajax request to the GraphQL
     endpoint, and returns a promise for the resulting payload.
 
     @method findRecord
@@ -36,7 +37,7 @@ export default DS.Adapter.extend({
     Called by the store in order to fetch a JSON array for all
     of the records for a given type.
 
-    The `findAll` method makes an Ajax (HTTP GET) request to the GraphQL
+    The `findAll` method makes an Ajax request to the GraphQL
     endpoint, and returns a promise for the resulting payload.
 
     @method findAll
@@ -60,7 +61,7 @@ export default DS.Adapter.extend({
     Called by the store in order to fetch JSON for
     the records that match a particular query.
 
-    The `query` method makes an Ajax (HTTP GET) request to the GraphQL
+    The `query` method makes an Ajax request to the GraphQL
     endpoint, and returns a promise for the resulting payload.
 
     The `query` argument is a simple JavaScript object that will be
@@ -88,7 +89,7 @@ export default DS.Adapter.extend({
     Called by the store in order to fetch JSON for a single record that
     matches a particular query.
 
-    The `query` method makes an Ajax (HTTP GET) request to the GraphQL
+    The `query` method makes an Ajax request to the GraphQL
     endpoint, and returns a promise for the resulting payload.
 
     The `query` argument is a simple JavaScript object that will be
@@ -162,7 +163,7 @@ export default DS.Adapter.extend({
     Called by the store when an existing record is saved
     via the `save` method on a model record instance.
 
-    The `updateRecord` method  makes an Ajax (HTTP GET) request to the GraphQL endpoint.
+    The `updateRecord` method  makes an Ajax request to the GraphQL endpoint.
 
     @method updateRecord
     @param {DS.Store} store
@@ -195,7 +196,7 @@ export default DS.Adapter.extend({
   /**
     Called by the store when a record is deleted.
 
-    The `deleteRecord` method  makes an Ajax (HTTP GET) request to the GraphQL endpoint.
+    The `deleteRecord` method  makes an Ajax request to the GraphQL endpoint.
 
     @method deleteRecord
     @param {DS.Store} store
@@ -311,6 +312,7 @@ export default DS.Adapter.extend({
       'url': url,
       'dataType': 'json',
       'data': data,
+      'type': this.httpMethod,
       'type': 'GET',
       'context': this
     };

--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -9,6 +9,10 @@ export default DS.Adapter.extend({
   defaultSerializer: '-graphql',
   coalesceFindRequests: false,
 
+  normalizeCase: function(string) {
+    return Ember.String.camelize(string);
+  },
+
   /**
     Called by the store in order to fetch the JSON for a given
     type and ID.
@@ -23,7 +27,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   findRecord: function(store, type, id) {
-    let operationName = this._normalizeModelName(type.modelName);
+    let operationName = this.normalizeCase(type.modelName);
 
     return this.request(store, type, {
       'rootFieldQuery': { 'id': id },
@@ -46,7 +50,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   findAll: function(store, type) {
-    let operationName = this._normalizeModelName(Ember.String.pluralize(type.modelName));
+    let operationName = this.normalizeCase(Ember.String.pluralize(type.modelName));
 
     let options = {
       'rootFieldName': operationName,
@@ -75,7 +79,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   query: function(store, type, query) {
-    let operationName = this._normalizeModelName(Ember.String.pluralize(type.modelName));
+    let operationName = this.normalizeCase(Ember.String.pluralize(type.modelName));
 
     return this.request(store, type, {
       'rootFieldName': operationName,
@@ -103,7 +107,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   queryRecord: function(store, type, query) {
-    let operationName = this._normalizeModelName(type.modelName);
+    let operationName = this.normalizeCase(type.modelName);
 
     return this.request(store, type, {
       'rootFieldName': operationName,
@@ -123,7 +127,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   findMany(store, type, ids) {
-    let operationName = this._normalizeModelName(Ember.String.pluralize(type.modelName));
+    let operationName = this.normalizeCase(Ember.String.pluralize(type.modelName));
 
     return this.request(store, type, {
       'rootFieldQuery': { 'ids': ids },
@@ -146,7 +150,7 @@ export default DS.Adapter.extend({
   createRecord: function(store, type, snapshot) {
     let data = {};
     let serializer = store.serializerFor(type.modelName);
-    let operationName = this._normalizeModelName(type.modelName);
+    let operationName = this.normalizeCase(type.modelName);
 
     serializer.serializeIntoHash(data, type, snapshot);
 
@@ -174,7 +178,7 @@ export default DS.Adapter.extend({
   updateRecord: function(store, type, snapshot) {
     let data = {};
     let serializer = store.serializerFor(type.modelName);
-    let operationName = this._normalizeModelName(type.modelName);
+    let operationName = this.normalizeCase(type.modelName);
 
     serializer.serializeIntoHash(data, type, snapshot);
 
@@ -206,7 +210,7 @@ export default DS.Adapter.extend({
   */
   deleteRecord: function(store, type, snapshot) {
     let data = this.serialize(snapshot, { includeId: true });
-    let operationName = this._normalizeModelName(type.modelName);
+    let operationName = this.normalizeCase(type.modelName);
 
     return this.request(store, type, {
       'rootFieldName': operationName + 'Delete',
@@ -226,6 +230,7 @@ export default DS.Adapter.extend({
     @return {String} result
   */
   compile: function(store, type, options) {
+    options['normalizeCaseFn'] = this.normalizeCase;
     return Compiler.compile(type, store, options);
   },
 
@@ -358,10 +363,6 @@ export default DS.Adapter.extend({
     } else {
       return payload;
     }
-  },
-
-  _normalizeModelName: function(modelName) {
-    return Ember.String.camelize(modelName);
   }
 });
 

--- a/addon/compiler.js
+++ b/addon/compiler.js
@@ -16,7 +16,9 @@ export default {
     let rootFieldAlias = options['rootFieldAlias'];
     let rootField = new Field(rootFieldName, rootFieldAlias, ArgumentSet.fromQuery(rootFieldQuery));
 
-    let parseTree = Parser.parse(model, store, operation, rootField);
+    let normalizeCaseFn = options['normalizeCaseFn'];
+
+    let parseTree = Parser.parse(model, store, operation, rootField, normalizeCaseFn);
 
     return Generator.generate(parseTree);
   }

--- a/addon/parser.js
+++ b/addon/parser.js
@@ -17,7 +17,8 @@ export default {
         rootField.selectionSet.push(field);
       } else {
         let relModel = store.modelFor(type);
-        let modelName = kind === 'hasMany' ? Ember.String.pluralize(type) : type;
+        let camelizedType = Ember.String.camelize(type);
+        let modelName = kind === 'hasMany' ? Ember.String.pluralize(camelizedType) : camelizedType;
         let alias = modelName !== relName && relName;
 
         let field = new Type.Field(

--- a/addon/parser.js
+++ b/addon/parser.js
@@ -50,8 +50,8 @@ export default {
       new Type.SelectionSet(new Type.Field('id'))
     );
 
-    relModel.eachAttribute(function(attr) {
-      let relField = new Type.Field(attr);
+    relModel.eachAttribute((attr) => {
+      let relField = this._buildField(attr, normalizeCaseFn);
       field.selectionSet.push(relField);
     });
 

--- a/addon/parser.js
+++ b/addon/parser.js
@@ -10,35 +10,62 @@ export default {
       rootField.selectionSet.push(field);
     });
 
-    model.eachRelationship((relName, {kind, type, options}) => {
+    model.eachRelationship((relName, relationship) => {
+      let field;
+      let {type, options} = relationship;
+
       if (options.async) {
-        let suffix = kind === 'hasMany' ? 'Ids' : 'Id';
-        let field = new Type.Field(Ember.String.singularize(relName) + suffix);
-        rootField.selectionSet.push(field);
+        field = this._buildAsyncRelationship(relName, relationship);
       } else {
         let relModel = store.modelFor(type);
-        let camelizedType = Ember.String.camelize(type);
-        let modelName = kind === 'hasMany' ? Ember.String.pluralize(camelizedType) : camelizedType;
-        let alias = modelName !== relName && relName;
-
-        let field = new Type.Field(
-          modelName,
-          alias,
-          new Type.ArgumentSet(),
-          new Type.SelectionSet(new Type.Field('id'))
-        );
-
-        relModel.eachAttribute(function(attr) {
-          let relField = new Type.Field(attr);
-          field.selectionSet.push(relField);
-        });
-
-        rootField.selectionSet.push(field);
+        field = this._buildSyncRelationship(relModel, relName, relationship);
       }
+
+      rootField.selectionSet.push(field);
     });
 
     operation.selectionSet.push(rootField);
 
     return operation;
+  },
+
+  _buildAsyncRelationship(relName, {kind}) {
+    let suffix = kind === 'hasMany' ? 'Ids' : 'Id';
+    return new Type.Field(Ember.String.singularize(relName) + suffix);
+  },
+
+  _buildSyncRelationship(relModel, relName, {kind, type}) {
+    let normalizedType = this._getNormalizedType(kind, type);
+    let aliasedNameOrNull = this._getAliasedName(relName, normalizedType);
+
+    let field = new Type.Field(
+      normalizedType,
+      aliasedNameOrNull,
+      new Type.ArgumentSet(),
+      new Type.SelectionSet(new Type.Field('id'))
+    );
+
+    relModel.eachAttribute(function(attr) {
+      let relField = new Type.Field(attr);
+      field.selectionSet.push(relField);
+    });
+
+    return field;
+  },
+
+  _getNormalizedType(kind, type) {
+    let camelizedType = Ember.String.camelize(type);
+
+    if (kind === 'hasMany') {
+      return Ember.String.pluralize(camelizedType);
+    } else {
+      return camelizedType;
+    }
+  },
+
+  _getAliasedName(relName, normalizedType) {
+    if (relName !== normalizedType) {
+      return relName;
+    }
   }
 };

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -149,17 +149,17 @@ export default DS.JSONAPISerializer.extend({
     return relationships;
   },
 
-  __buildRelationships: function(type, collection, extractIdFn) {
-    if (!collection) {
+  __buildRelationships: function(type, data, extractIdFn) {
+    if (!data) {
       return;
     }
 
-    if (Ember.typeOf(collection) !== 'array') {
-      return this.__buildRelationship(extractIdFn(collection), type);
-    } else {
-      return collection.map((elem) => {
+    if (Ember.typeOf(data) === 'array') {
+      return data.map((elem) => {
         return this.__buildRelationship(extractIdFn(elem), type);
       });
+    } else {
+      return this.__buildRelationship(extractIdFn(data), type);
     }
   },
 

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,9 @@
 {
   "name": "ember-graphql-adapter",
   "dependencies": {
-    "ember": "1.13.11",
-    "ember-cli-shims": "0.0.6",
+    "ember": "2.2.0",
+    "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.1",
-    "ember-data": "1.13.15",
     "ember-load-initializers": "0.1.7",
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.15",
+    "ember-data": "2.3.3",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.0.0",

--- a/tests/helpers/model-double.js
+++ b/tests/helpers/model-double.js
@@ -5,5 +5,9 @@ export default function ModelDouble(name, attributes, relationships) {
 
   this.eachAttribute = (cb, binding) => { this.attributes.forEach(cb, binding); };
   this.eachTransformedAttribute = function() {};
-  this.eachRelationship = (cb) => { this.relationships.forEach(cb); };
+  this.eachRelationship = (cb) => {
+    this.relationships.forEach(function([relName, relationship]) {
+      cb(relName, relationship);
+    });
+  };
 }

--- a/tests/helpers/snapshot-double.js
+++ b/tests/helpers/snapshot-double.js
@@ -1,7 +1,16 @@
+import Ember from 'ember';
+
+let MockObject = Ember.Object.extend({
+  has: function() {
+    return true;
+  }
+});
+
 export default function SnapshotDouble(modelName, attributes, relationships) {
-  this.attributes = attributes || {};
-  this.relationships = relationships || {};
+  this.attributes = MockObject.create(attributes || {});
+  this.relationships = MockObject.create(relationships || {});
   this.modelName = modelName;
+  this.type = this;
 
   this.eachAttribute = function(cb, binding) {
     let attrs = Object.keys(this.attributes);

--- a/tests/helpers/store-double.js
+++ b/tests/helpers/store-double.js
@@ -3,6 +3,7 @@ import Serializer from 'ember-graphql-adapter/serializer';
 export default function StoreDouble(map) {
   this.map = map;
   this.modelFor = (type) => { return this.map[type]; };
+  this._hasModelFor = this.modelFor;
   this.serializerFor = () => {
     let serializer = new Serializer();
     serializer.store = this;

--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -70,4 +70,3 @@ export {setupStore};
 export function createStore(options) {
   return setupStore(options).store;
 }
-

--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -55,6 +55,7 @@ export default function setupStore(options) {
   registry.register('serializer:-graphql', Serializer);
 
   registry.register('transform:string', DS.StringTransform);
+  registry.register('transform:number', DS.NumberTransform);
 
   env.restSerializer = container.lookup('serializer:-rest');
   env.store = container.lookup('service:store');

--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -281,9 +281,10 @@ test('deleteRecord - deletes existing record', function(assert) {
 });
 
 test('Synchronous relationships are included', function(assert) {
-  assert.expect(8);
+  assert.expect(10);
 
   Post.reopen({
+    postCategory: DS.belongsTo('postCategory', { async: false }),
     comments: DS.hasMany('comment', { async: false }),
     topComments: DS.hasMany('comment', { async: false })
   });
@@ -293,6 +294,7 @@ test('Synchronous relationships are included', function(assert) {
       post: {
         id: '1',
         name: 'Ember.js rocks',
+        postCategory: { id: '1', name: 'Tutorials' },
         comments: [
           { id: '1', name: 'FIRST' }
         ],
@@ -306,10 +308,13 @@ test('Synchronous relationships are included', function(assert) {
   run(function() {
     store.findRecord('post', 1).then(function(post) {
       assert.equal(passedUrl, '/graph');
-      assert.equal(passedQuery, 'query post { post(id: "1") { id name comments { id name } topComments: comments { id name } } }');
+      assert.equal(passedQuery, 'query post { post(id: "1") { id name postCategory { id name } comments { id name } topComments: comments { id name } } }');
 
       assert.equal(post.get('id'), '1');
       assert.equal(post.get('name'), 'Ember.js rocks');
+
+      assert.equal(post.get('postCategory.id'), '1');
+      assert.equal(post.get('postCategory.name'), 'Tutorials');
 
       assert.equal(post.get('comments.firstObject.id'), '1');
       assert.equal(post.get('comments.firstObject.name'), 'FIRST');

--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -432,3 +432,36 @@ test('Resources and attributes with multiple words are camelized', function(asse
     });
   });
 });
+
+test('Resources and attributes with multiple words are snake cased in times of need', function(assert) {
+  assert.expect(5);
+
+  adapter.normalizeCase = function(name) {
+    return Ember.String.underscore(name);
+  };
+
+  PostCategory.reopen({
+    postsCount: DS.attr('number')
+  });
+
+  ajaxResponse({
+    data: {
+      postCategory: {
+        id: '1',
+        name: 'Ember.js rocks',
+        postsCount: '10'
+      }
+    }
+  });
+
+  run(function() {
+    store.findRecord('postCategory', 1).then(function(category) {
+      assert.equal(passedUrl, '/graph');
+      assert.equal(passedQuery, 'query post_category { post_category(id: "1") { id name posts_count } }');
+
+      assert.equal(category.get('id'), '1');
+      assert.equal(category.get('name'), 'Ember.js rocks');
+      assert.equal(category.get('postsCount'), 10);
+    });
+  });
+});

--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -1,7 +1,7 @@
 import setupStore from 'dummy/tests/helpers/store';
 import Ember from 'ember';
 import {module, test} from 'qunit';
-import Adapter from 'ember-graphql-adapter';
+import {Adapter, Serializer} from 'ember-graphql-adapter';
 
 var env, store, adapter;
 var passedUrl, passedQuery;
@@ -436,9 +436,15 @@ test('Resources and attributes with multiple words are camelized', function(asse
 test('Resources and attributes with multiple words are snake cased in times of need', function(assert) {
   assert.expect(5);
 
-  adapter.normalizeCase = function(name) {
+  let normalizeCaseFn = function(name) {
     return Ember.String.underscore(name);
   };
+
+  adapter.normalizeCase = normalizeCaseFn;
+
+  env.registry.register('serializer:-graphql', Serializer.extend({
+    normalizeCase: normalizeCaseFn
+  }));
 
   PostCategory.reopen({
     postsCount: DS.attr('number')
@@ -446,10 +452,10 @@ test('Resources and attributes with multiple words are snake cased in times of n
 
   ajaxResponse({
     data: {
-      postCategory: {
+      post_category: {
         id: '1',
         name: 'Ember.js rocks',
-        postsCount: '10'
+        posts_count: '10'
       }
     }
   });

--- a/tests/unit/compiler-test.js
+++ b/tests/unit/compiler-test.js
@@ -1,9 +1,14 @@
 import { test, module } from 'qunit';
+import Ember from 'ember';
 import ModelDouble from '../helpers/model-double';
 import StoreDouble from '../helpers/store-double';
 import Compiler from 'ember-graphql-adapter/compiler';
 
 module('unit:ember-graphql-adapter/compiler');
+
+const normalizeCaseFn = function(string) {
+  return Ember.String.camelize(string);
+};
 
 test("takes an Model and responds with GraphQL query", function(assert) {
   let model = new ModelDouble('project', ['status']);
@@ -15,7 +20,8 @@ test("takes an Model and responds with GraphQL query", function(assert) {
     'rootFieldQuery': {
       'status': 'active',
       'limit': 10
-    }
+    },
+    'normalizeCaseFn': normalizeCaseFn
   };
 
   assert.equal(Compiler.compile(model, store, options), 'query projectsQuery { projects(status: "active", limit: 10) { id status } }');
@@ -31,7 +37,8 @@ test("mutation", function(assert){
     'rootFieldQuery': {
       'name': 'Test Project',
       'status': 'active'
-    }
+    },
+    'normalizeCaseFn': normalizeCaseFn
   };
 
   assert.equal(Compiler.compile(model, store, options), 'mutation projectCreate { projectCreate(name: "Test Project", status: "active") { id name status } }');
@@ -48,7 +55,8 @@ test("mutation with root alias", function(assert){
     'rootFieldQuery': {
       'name': 'Test Project',
       'status': 'active'
-    }
+    },
+    'normalizeCaseFn': normalizeCaseFn
   };
 
   assert.equal(Compiler.compile(model, store, options), 'mutation projectCreate { project: projectCreate(name: "Test Project", status: "active") { id name status } }');

--- a/tests/unit/parser-test.js
+++ b/tests/unit/parser-test.js
@@ -7,7 +7,11 @@ import StoreDouble from '../helpers/store-double';
 
 module('unit:ember-graphql-adapter/parser', {
   setup: function() {
-    let projectModel = new ModelDouble('projects', ['status', 'name'], ['user']);
+    let projectModel = new ModelDouble(
+      'projects',
+      ['status', 'name'],
+      [['user', { type: 'user', kind: 'belongsTo', options: { async: false }}]]
+    );
     let userModel = new ModelDouble('user', ['name']);
     let store = new StoreDouble({ 'project': projectModel, 'user': userModel });
 

--- a/tests/unit/parser-test.js
+++ b/tests/unit/parser-test.js
@@ -1,9 +1,14 @@
 import { test, module } from 'qunit';
+import Ember from 'ember';
 import Parser from 'ember-graphql-adapter/parser';
 import * as Type from 'ember-graphql-adapter/types';
 import ArgumentSet from 'ember-graphql-adapter/types/argument-set';
 import ModelDouble from '../helpers/model-double';
 import StoreDouble from '../helpers/store-double';
+
+const normalizeCaseFn = function(string) {
+  return Ember.String.camelize(string);
+};
 
 module('unit:ember-graphql-adapter/parser', {
   setup: function() {
@@ -18,7 +23,7 @@ module('unit:ember-graphql-adapter/parser', {
     let rootField = new Type.Field('projects');
     let operation = new Type.Operation('query', 'projectsQuery', ArgumentSet.fromQuery({ status: 'active' }));
 
-    this.parseTree = Parser.parse(projectModel, store, operation, rootField);
+    this.parseTree = Parser.parse(projectModel, store, operation, rootField, normalizeCaseFn);
   }
 });
 

--- a/tests/unit/serializer-test.js
+++ b/tests/unit/serializer-test.js
@@ -84,8 +84,63 @@ test ('normalizing simple scalars in array payload', function(assert) {
   assert.deepEqual(serializer.normalizeResponse(store, postModel, payload, '1', 'query'), expectedNormalization);
 });
 
-test('normalizing with relationships', function(assert) {
-  let postModel = new ModelDouble('post', ['title', 'body'], ['user', 'comments']);
+test('normalizing with asynchronous relationships', function(assert) {
+  let postModel = new ModelDouble('post', ['title', 'body'], [
+    ['user', { kind: 'belongsTo', type: 'user', options: { async: true }}],
+    ['comments', { kind: 'hasMany', type: 'comment', options: { async: true }}]
+  ]);
+  let userModel = new ModelDouble('user', ['email', 'name']);
+  let commentModel = new ModelDouble('comment', ['body']);
+  let store = new StoreDouble({ 'post': postModel, 'user': userModel, 'comment': commentModel });
+  let serializer = new Serializer();
+  serializer.store = store;
+
+  let payload = {
+    'data': {
+      'post': {
+        'id': '1',
+        'title': 'The post title',
+        'body': 'The body title',
+        'userId': '2',
+        'commentIds': ['3', '4']
+      }
+    }
+  };
+
+  let expectedNormalization = {
+    'data': {
+      'type': 'post',
+      'id': '1',
+      'attributes': {
+        'title': 'The post title',
+        'body': 'The body title',
+      },
+      'relationships': {
+        'user': {
+          'data': {
+            'type': 'user',
+            'id': '2'
+          }
+        },
+        'comments': {
+          'data': [
+            { 'type': 'comment', 'id': '3' },
+            { 'type': 'comment', 'id': '4' }
+          ]
+        }
+      }
+    },
+    'included': []
+  };
+
+  assert.deepEqual(serializer.normalizeResponse(store, postModel, payload, '1', 'findRecord'), expectedNormalization);
+});
+
+test('normalizing with synchronous relationships', function(assert) {
+  let postModel = new ModelDouble('post', ['title', 'body'], [
+    ['user', { kind: 'belongsTo', type: 'user', options: { async: false }}],
+    ['comments', { kind: 'hasMany', type: 'comment', options: { async: false }}]
+  ]);
   let userModel = new ModelDouble('user', ['email', 'name']);
   let commentModel = new ModelDouble('comment', ['body']);
   let store = new StoreDouble({ 'post': postModel, 'user': userModel, 'comment': commentModel });


### PR DESCRIPTION
This PR adds support for both synchronous and asynchronous `hasMany` associations.

### Bonus

Users can now select their own HTTP method for the GraphQL endpoint.