### PR TITLE
Stringify Individual Array Elements

### DIFF
--- a/addon/generator.js
+++ b/addon/generator.js
@@ -51,13 +51,23 @@ export default {
 
   generateArgument({name, value}) {
     if (Ember.typeOf(value) === 'string') {
-      value = this.argumentStringWrapperToken + value + this.argumentStringWrapperToken;
+      value = this.wrapInStringTokens(value);
     } else if (Ember.typeOf(value) === 'array') {
-      value = this.argumentArrayOpeningToken + value + this.argumentArrayClosingToken;
+      value = this.argumentArrayOpeningToken + this.wrapArrayInStringTokens(value) + this.argumentArrayClosingToken;
     } else if (Ember.typeOf(value) === 'object') {
       value = this.argumentObjectOpeningToken + this.generateArgumentSet(value) + this.argumentObjectClosingToken;
     }
 
     return name + this.argumentKeyValueSeparateToken + value;
+  },
+
+  wrapArrayInStringTokens(array) {
+    return array.map((ele) => {
+      return this.wrapInStringTokens(ele);
+    }).join();
+  },
+
+  wrapInStringTokens(value) {
+    return this.argumentStringWrapperToken + value + this.argumentStringWrapperToken;
   }
 };

--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -176,7 +176,7 @@ test('findMany - finds many records coalescing in a single request', function(as
   run(function() {
     post.get('comments').then(function(comments) {
       assert.equal(passedUrl, '/graph');
-      assert.equal(passedQuery, 'query comments { comments(ids: [1,2,3]) { id name } }');
+      assert.equal(passedQuery, 'query comments { comments(ids: ["1","2","3"]) { id name } }');
       assert.equal(comments.length, 3);
     });
   });

--- a/tests/unit/generator-test.js
+++ b/tests/unit/generator-test.js
@@ -27,5 +27,5 @@ test('all the things', function(assert) {
   let operationArgumentSet = new Type.ArgumentSet();
   let operation = new Type.Operation('query', 'postsQuery', operationArgumentSet, operationSelectionSet);
 
-  assert.equal(Generator.generate(operation), `query postsQuery { postAlias: post(ids: [1,2,3], status: "active", embedded: { id: 1 }, limit: 10, offset: 0) { id status author { id username } } }`);
+  assert.equal(Generator.generate(operation), `query postsQuery { postAlias: post(ids: ["1","2","3"], status: "active", embedded: { id: 1 }, limit: 10, offset: 0) { id status author { id username } } }`);
 });


### PR DESCRIPTION
### What's Up

There is a discrepancy in the way that queries are formed with respect to requests for one elements versus a set of elements.

At this time, when the argument is one id, the adapter wraps the id in string tokens, a la `items(id: "1")`. However, when the argument is in array, it does not stringify each individual element, so the request looks like `items(ids: [1,2,3])`. This is an issue because it makes an assumptions that ids will always be integers - this might be the case for a majority of cases in Rails, but it prevents any sort of customization that might appear when particular Models have non-traditional id conventions.

### What This Does

This PR surrounds individual array elements with string tokens to solve the above issue. To do this, it creates a method `wrapArrayInStringTokens`, which surrounds each individual item in the array with string tokens. As a result of needing to string tokenize elements elsewhere, it refactors that action into its own method `wrapInStringTokens`.