### PR TITLE
Escape quotes in strings

### DIFF
--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -559,3 +559,41 @@ test('Mutation names can be snake cased too', function(assert) {
     });
   });
 });
+
+test('Saving a record with a quotes in a string attribute', function(assert) {
+  assert.expect(3);
+
+  run(function() {
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        attributes: {
+          name: 'Rails is omakase'
+        }
+      }
+    });
+  });
+
+  ajaxResponse({
+    data: {
+      post: {
+        id: '1',
+        name: 'Ember.js is "da bomb".'
+      }
+    }
+  });
+
+  run(function() {
+    let post = store.peekRecord('post', 1);
+
+    post.set('name', 'Ember.js is "da bomb".');
+
+    post.save().then(function(post) {
+      assert.equal(passedUrl, '/graph');
+      assert.equal(passedQuery, 'mutation postUpdate { post: postUpdate(id: "1", name: "Ember.js is \\"da bomb\\".") { id name } }');
+
+      assert.equal(post.get('name'), 'Ember.js is "da bomb".');
+    });
+  });
+});


### PR DESCRIPTION
### What's up
The GraphQL spec defines a string as being enclosed in double quotes. However, if a string attribute were to have a double quoted character sequence within itself, then we would be faced with GraphQL parsing errors. For example,

```
mutation user_update { user: user_update(id: "1", name: "Jeff "The Jeff" Reine-Adelaide") { id name } }
```

The above results in the server thinking that the string value of the `name` argument is `"Jeff "`, and it promptly complains about the succeeding character `T` which it doesn't expect.