### PR TITLE
Support inclusion of meta information

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -82,10 +82,14 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
 
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
     let data = payload['data'];
+    let meta = payload['meta'];
+
     const type = this.normalizeCase(primaryModelClass.modelName);
     const root = data[type] || data[pluralize(type)];
 
     Ember.assert('The root of the result must be the model class name or the plural model class name', Ember.typeOf(root) !== 'undefined');
+
+    if (meta) { root['meta'] = meta; }
 
     return this._super(store, primaryModelClass, root, id, requestType);
   },

--- a/tests/integration/serializer-test.js
+++ b/tests/integration/serializer-test.js
@@ -245,6 +245,52 @@ test('normalize - synchronous relationships', function(assert) {
   });
 });
 
+test('normalize - meta', function(assert) {
+  assert.expect(1);
+
+  let id = '1';
+  let method = 'query';
+  let modelName = 'post';
+
+  let payload = {
+    'data': {
+      'posts': [{
+        'id': '1',
+        'title': 'The post title'
+      }]
+    },
+    'meta': {
+      'total_count': 1,
+      'total_pages': 1,
+      'current_page': 1
+    }
+  };
+
+  let expected = {
+    'data': [{
+      'type': 'post',
+      'id': '1',
+      'attributes': {
+        'title': 'The post title'
+      },
+      'relationships': {}
+    }],
+    'included': [],
+    'meta': {
+      'total_count': 1,
+      'total_pages': 1,
+      'current_page': 1
+    }
+  };
+
+  run(function() {
+    let model = store.modelFor(modelName);
+    let serializer = store.serializerFor(modelName);
+    let result = serializer.normalizeResponse(store, model, payload, id, method);
+    assert.deepEqual(result, expected);
+  });
+});
+
 test('serialize - simple', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This PR adds support for custom meta information to be parsed by the graphql adapter. This can enable easy support for things like pagination or other types of metadata :)