### PR TITLE
Fix error when fetching a resource returns a null object

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -85,7 +85,10 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     let meta = payload['meta'];
 
     const type = this.normalizeCase(primaryModelClass.modelName);
-    const root = data[type] || data[pluralize(type)];
+    let root = data[type];
+    if (Ember.typeOf(root) === 'undefined') {
+      root = data[pluralize(type)];
+    }
 
     Ember.assert('The root of the result must be the model class name or the plural model class name', Ember.typeOf(root) !== 'undefined');
 

--- a/tests/integration/serializer-test.js
+++ b/tests/integration/serializer-test.js
@@ -44,6 +44,32 @@ module("integration/serializer - GraphQL serializer", {
   }
 });
 
+test('normalize - null record', function(assert) {
+  assert.expect(1);
+
+  let id = '1';
+  let method = 'findRecord';
+  let modelName = 'post';
+
+  let payload = {
+    'data': {
+      'post': null
+    }
+  };
+
+  let expected = {
+    'data': null,
+    'included': []
+  };
+
+  run(function() {
+    let model = store.modelFor(modelName);
+    let serializer = store.serializerFor(modelName);
+    let result = serializer.normalizeResponse(store, model, payload, id, method);
+    assert.deepEqual(result, expected);
+  });
+});
+
 test('normalize - single record', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
## What's up
Using a GraphQL server that returns a 200 response status for every request, we have to rely on the content of the payload to provide context for how successful the request was. 

Currently, if this request
`query { post(id: "1") { id title body } }`

returns with this payload
```
{
  'data': {
    'post': null
  }
}
```
we should interpret this as a not found ([see JSONAPI spec](http://jsonapi.org/format/#fetching-resources)).

Instead, we end up with an assertion error of this variety:
`Assertion Failed: The root of the result must be the model class name or the plural model class name`