### PR TITLE
Stop sending entire snapshot when saving records

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -156,13 +156,24 @@ export default DS.Adapter.extend({
 
     serializer.serializeIntoHash(data, type, snapshot);
 
+    let payload = { id: data['id'] };
+    Object.keys(snapshot.changedAttributes()).forEach(key => {
+      let payloadKey = serializer.keyForAttribute(key);
+      payload[payloadKey] = data[payloadKey];
+    });
+
+    snapshot.eachRelationship((key, {kind, options}) => {
+      let payloadKey = serializer.keyForRelationship(key, kind, options);
+      payload[payloadKey] = data[payloadKey];
+    });
+
     return this.request(store, type, {
       'operationName': operationName,
       'operationType': 'mutation',
       'parseSelectionSet': true,
       'rootFieldAlias': modelName,
       'rootFieldName': operationName,
-      'rootFieldQuery': data
+      'rootFieldQuery': payload
     });
   },
 


### PR DESCRIPTION
## What's up
https://github.com/alphasights/ember-graphql-adapter/pull/27 introduced sending entire snapshots back to the API. However, we cannot keep doing that if we want to properly support the explicit setting/unsetting behavior required by the introduction of the `null` value into the GraphQL spec.