### PR TITLE
Escape backslash in attributes

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -31,6 +31,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
       if (type) {
         if (type === 'string') {
           if (!Ember.isNone(value)) {
+            value = value.replace(/\\/g, '\\\\');
             value = value.replace(/\"/g, '\\"');
           }
         } else {

--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -597,3 +597,37 @@ test('Saving a record with a quotes in a string attribute', function(assert) {
     });
   });
 });
+
+test('Saving a record with a back slash in a string attribute', function(assert) {
+  assert.expect(2);
+
+  run(function() {
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        attributes: {
+          name: 'Rails is omakase'
+        }
+      }
+    });
+  });
+
+  ajaxResponse({
+    data: {
+      post: {
+        id: '1',
+        name: '\\\\Ember.js is da bomb.'
+      }
+    }
+  });
+
+  run(function() {
+    let post = store.peekRecord('post', 1);
+
+    post.save().then(function(post) {
+      assert.equal(passedUrl, '/graph');
+      assert.equal(passedQuery, 'mutation postUpdate { post: postUpdate(id: "1", name: "\\\\Ember.js is da bomb.") { id name } }');
+    });
+  });
+});


### PR DESCRIPTION
There is currently a parsing error if you try to send back a \ in an attribute (similar to the " error).  These (the \ and the ") are the most common parsing errors with graphql, but if there are more we might want to look into a more sustainable way of addressing this, rather than just adding more lines of replacements. 