### PR TITLE
Fix erroneous nesting for reflexive relationships

### DIFF
--- a/addon/parser.js
+++ b/addon/parser.js
@@ -36,7 +36,7 @@ class Parser {
             field = this._buildAsyncRelationship(relName, relationship);
           } else {
             let relModel = store.modelFor(type);
-            if (!this.visited.includes(relName)) {
+            if (this.visited.indexOf(relName) === -1) {
               field = new Type.Field(
                 this.normalizeCaseFn(relName),
                 null,

--- a/addon/parser.js
+++ b/addon/parser.js
@@ -10,12 +10,49 @@ class Parser {
   }
 
   parse(model, store, operation, rootField) {
-    rootField.selectionSet.push(new Type.Field('id'));
-
     if (this.parseSelectionSet) {
-      this.agenda.unshift(model);
-      this.visited.push(model.modelName);
-      this._recursiveParse(store, rootField);
+      this.agenda.push({ name: model.modelName, model, field: rootField });
+
+      while (this.agenda.length > 0) {
+        let current = this.agenda.shift();
+        this.visited.push(current.name);
+
+        let currentModel = current.model;
+        let currentField = current.field;
+
+        currentField.selectionSet.push(new Type.Field('id'));
+
+        /*jshint loopfunc: true */
+        currentModel.eachAttribute((attr) => {
+          let field = this._buildField(attr);
+          currentField.selectionSet.push(field);
+        });
+
+        currentModel.eachRelationship((relName, relationship) => {
+          let field;
+          let { type, options } = relationship;
+
+          if (options.async) {
+            field = this._buildAsyncRelationship(relName, relationship);
+          } else {
+            let relModel = store.modelFor(type);
+            if (!this.visited.includes(relName)) {
+              field = new Type.Field(
+                this.normalizeCaseFn(relName),
+                null,
+                new Type.ArgumentSet(),
+                new Type.SelectionSet()
+              );
+              this.agenda.push({ name: relName, model: relModel, field });
+            }
+          }
+          if (field) {
+            currentField.selectionSet.push(field);
+          }
+        });
+      }
+    } else {
+      rootField.selectionSet.push(new Type.Field('id'));
     }
 
     operation.selectionSet.push(rootField);
@@ -27,50 +64,9 @@ class Parser {
     return new Type.Field(this.normalizeCaseFn(attr));
   }
 
-  _buildAsyncRelationship(relName, {kind}) {
+  _buildAsyncRelationship(relName, { kind }) {
     let suffix = kind === 'hasMany' ? 'Ids' : 'Id';
     return this._buildField(Ember.String.singularize(relName) + suffix);
-  }
-
-  _buildSyncRelationship(store, relName) {
-    let field = new Type.Field(
-      this.normalizeCaseFn(relName),
-      null,
-      new Type.ArgumentSet(),
-      new Type.SelectionSet(new Type.Field('id'))
-    );
-
-    this._recursiveParse(store, field);
-
-    return field;
-  }
-
-  _recursiveParse(store, field) {
-    let currentModel = this.agenda.pop();
-    currentModel.eachAttribute((attr) => {
-      let relField = this._buildField(attr);
-      field.selectionSet.push(relField);
-    });
-
-    currentModel.eachRelationship((relName, relationship) => {
-      let relField;
-      let {type, options} = relationship;
-
-      if (options.async) {
-        relField = this._buildAsyncRelationship(relName, relationship);
-      } else {
-        let relModel = store.modelFor(type);
-        if (this.visited.indexOf(relName) === -1) {
-          this.agenda.unshift(relModel);
-          this.visited.push(relName);
-          relField = this._buildSyncRelationship(store, relName);
-        }
-      }
-
-      if (relField) {
-        field.selectionSet.push(relField);
-      }
-    });
   }
 }
 


### PR DESCRIPTION
### Problem
Given a model as such:

```javascript
// app/models/node.js
import DS from 'ember-data';

export default DS.Model.extend({
  name: DS.attr('string'),
  parent: DS.hasMany('node', { inverse: 'children' }),
  children: DS.hasMany('node', { inverse: 'parent' })
});
```

We are generating this query:
```graphql
query node {
  node(id: "my_node_id") {
    id
    name
    parents {
      id
      name
      children {
        id
        name
      }
    }
  }
}
```

This is a side effect of the recursion used to implement the support for
deeply nested synchronous relationships.

### Solution
Switch to an iterative algorithm for traversing the model tree.

We now get a query like this:
```graphql
query node {
  node(id: "my_node_id") {
    id
    name
    parent {
      id
      name
      children {
        id
        name
      }
    }
    children {
      id
      name
    }
  }
}
```

Fixes https://github.com/alphasights/ember-graphql-adapter/issues/75