### PR TITLE
Stop extending Array

### DIFF
--- a/addon/generator.js
+++ b/addon/generator.js
@@ -30,11 +30,11 @@ export default {
 
     acc = acc + field.name;
 
-    if (field.argumentSet.length > 0) {
+    if (field.argumentSet.toArray().length > 0) {
       acc = acc + `${this.argumentSetOpeningToken}${this.generateArgumentSet(field.argumentSet)}${this.argumentSetClosingToken}`;
     }
 
-    if (field.selectionSet.length > 0) {
+    if (field.selectionSet.toArray().length > 0) {
       acc = acc + `${this.openingToken}${this.generateSelectionSet(field.selectionSet)}${this.closingToken}`;
     }
 
@@ -42,11 +42,11 @@ export default {
   },
 
   generateSelectionSet(set) {
-    return set.map(field => this.generateField(field)).join('');
+    return set.toArray().map(field => this.generateField(field)).join('');
   },
 
   generateArgumentSet(set) {
-    return set.map(argument => this.generateArgument(argument)).join(this.argumentSeparatorToken);
+    return set.toArray().map(argument => this.generateArgument(argument)).join(this.argumentSeparatorToken);
   },
 
   generateArgument({name, value}) {

--- a/addon/generator.js
+++ b/addon/generator.js
@@ -30,11 +30,11 @@ export default {
 
     acc = acc + field.name;
 
-    if (field.argumentSet.toArray().length > 0) {
+    if (field.argumentSet.length > 0) {
       acc = acc + `${this.argumentSetOpeningToken}${this.generateArgumentSet(field.argumentSet)}${this.argumentSetClosingToken}`;
     }
 
-    if (field.selectionSet.toArray().length > 0) {
+    if (field.selectionSet.length > 0) {
       acc = acc + `${this.openingToken}${this.generateSelectionSet(field.selectionSet)}${this.closingToken}`;
     }
 

--- a/addon/types/argument-set.js
+++ b/addon/types/argument-set.js
@@ -1,20 +1,31 @@
 import { Argument } from '../types';
 import Ember from 'ember';
 
-export default class ArgumentSet extends Array {
+const { typeOf } = Ember;
+
+export default class ArgumentSet {
   constructor(...args) {
-    super();
-    this.push(...args);
+    this.items = [...args];
   }
 
   push(...args) {
-    super.push(...args.filter((arg) => {
-      if (Ember.typeOf(arg) === 'object') {
-        return Ember.typeOf(arg.value) !== 'undefined';
+    let filteredArgs = args.filter(arg => {
+      if (typeOf(arg) === 'object') {
+        return typeOf(arg.value) !== 'undefined';
       } else {
-        return Ember.typeOf(arg) !== 'undefined';
+        return typeOf(arg) !== 'undefined';
       }
-    }));
+    });
+
+    this.items.push(...filteredArgs);
+  }
+
+  pop() {
+    return this.items.pop();
+  }
+
+  toArray() {
+    return new Array(...this.items);
   }
 
   static fromQuery(query) {
@@ -23,7 +34,7 @@ export default class ArgumentSet extends Array {
     Object.keys(query).forEach((key) => {
       let arg = new Argument(key);
 
-      if (Ember.typeOf(query[key]) === 'object') {
+      if (typeOf(query[key]) === 'object') {
         arg.value = this.fromQuery(query[key]);
       } else {
         arg.value = query[key];

--- a/addon/types/argument-set.js
+++ b/addon/types/argument-set.js
@@ -28,6 +28,14 @@ export default class ArgumentSet {
     return new Array(...this.items);
   }
 
+  get length() {
+    return this.toArray().length;
+  }
+
+  get(index) {
+    return this.toArray()[index];
+  }
+
   static fromQuery(query) {
     let set = new ArgumentSet();
 

--- a/addon/types/selection-set.js
+++ b/addon/types/selection-set.js
@@ -1,6 +1,17 @@
-export default class SelectionSet extends Array {
+export default class SelectionSet {
   constructor(...args) {
-    super();
-    this.push(...args);
+    this.items = [...args];
+  }
+
+  push(...args) {
+    this.items.push(...args);
+  }
+
+  pop() {
+    return this.items.pop();
+  }
+
+  toArray() {
+    return new Array(...this.items);
   }
 }

--- a/addon/types/selection-set.js
+++ b/addon/types/selection-set.js
@@ -14,4 +14,12 @@ export default class SelectionSet {
   toArray() {
     return new Array(...this.items);
   }
+
+  get length() {
+    return this.toArray().length;
+  }
+
+  get(index) {
+    return this.toArray()[index];
+  }
 }

--- a/tests/unit/parser-test.js
+++ b/tests/unit/parser-test.js
@@ -62,25 +62,25 @@ test('makes the root of the tree an Operation', function(assert) {
 
   let rootSelectionSet = projectsParseTree.selectionSet;
   assert.equal(rootSelectionSet instanceof Type.SelectionSet, true);
-  assert.equal(rootSelectionSet.length, 1);
+  assert.equal(rootSelectionSet.toArray().length, 1);
 });
 
 test('root field is generated in the selection set', function(assert){
-  let rootField = projectsParseTree.selectionSet[0];
+  let rootField = projectsParseTree.selectionSet.toArray()[0];
   assert.equal(rootField instanceof Type.Field, true);
   assert.equal(rootField.name, 'projects');
 });
 
 test('there are as many elements in the selection set as there are top level fields (plus the id field)', function(assert){
-  let rootField = projectsParseTree.selectionSet[0];
+  let rootField = projectsParseTree.selectionSet.toArray()[0];
   let projectsSelectionSet = rootField.selectionSet;
 
-  assert.equal(projectsSelectionSet.length, 4);
+  assert.equal(projectsSelectionSet.toArray().length, 4);
 });
 
 test('nested fields are generated in the root field selection set', function(assert){
-  let rootField = projectsParseTree.selectionSet[0];
-  let projectsSelectionSet = rootField.selectionSet;
+  let rootField = projectsParseTree.selectionSet.toArray()[0];
+  let projectsSelectionSet = rootField.selectionSet.toArray();
 
   let expectedIdField = projectsSelectionSet[0];
   assert.equal(expectedIdField instanceof Type.Field, true);
@@ -98,66 +98,66 @@ test('nested fields are generated in the root field selection set', function(ass
   assert.equal(expectedUserField instanceof Type.Field, true);
   assert.equal(expectedUserField.name, 'user');
 
-  let expectedUserIdField = expectedUserField.selectionSet[0];
+  let expectedUserIdField = expectedUserField.selectionSet.toArray()[0];
   assert.equal(expectedUserIdField instanceof Type.Field, true);
   assert.equal(expectedUserIdField.name, 'id');
 
-  let expectedUserNameField = expectedUserField.selectionSet[1];
+  let expectedUserNameField = expectedUserField.selectionSet.toArray()[1];
   assert.equal(expectedUserNameField instanceof Type.Field, true);
   assert.equal(expectedUserNameField.name, 'name');
 
-  let expectedUserAddressField = expectedUserField.selectionSet[2];
+  let expectedUserAddressField = expectedUserField.selectionSet.toArray()[2];
   assert.equal(expectedUserAddressField instanceof Type.Field, true);
   assert.equal(expectedUserAddressField.name, 'address');
 
-  let expectedUserAddressIdField = expectedUserAddressField.selectionSet[0];
+  let expectedUserAddressIdField = expectedUserAddressField.selectionSet.toArray()[0];
   assert.equal(expectedUserAddressIdField instanceof Type.Field, true);
   assert.equal(expectedUserAddressIdField.name, 'id');
 
-  let expectedUserAddressCityField = expectedUserAddressField.selectionSet[1];
+  let expectedUserAddressCityField = expectedUserAddressField.selectionSet.toArray()[1];
   assert.equal(expectedUserAddressCityField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCityField.name, 'city');
 
-  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet[2];
+  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet.toArray()[2];
   assert.equal(expectedUserAddressCountryField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCountryField.name, 'country');
 });
 
 test('belongsTo id injection', function(assert) {
-  let rootField = projectsParseTree.selectionSet[0];
-  let projectsSelectionSet = rootField.selectionSet;
+  let rootField = projectsParseTree.selectionSet.toArray()[0];
+  let projectsSelectionSet = rootField.selectionSet.toArray();
   let expectedUserField = projectsSelectionSet[3];
 
-  assert.equal(expectedUserField.selectionSet.length, 3);
+  assert.equal(expectedUserField.selectionSet.toArray().length, 3);
 
-  let expectedUserIdField = expectedUserField.selectionSet[0];
+  let expectedUserIdField = expectedUserField.selectionSet.toArray()[0];
   assert.equal(expectedUserIdField instanceof Type.Field, true);
   assert.equal(expectedUserIdField.name, 'id');
 
-  let expectedUserNameField = expectedUserField.selectionSet[1];
+  let expectedUserNameField = expectedUserField.selectionSet.toArray()[1];
   assert.equal(expectedUserNameField instanceof Type.Field, true);
   assert.equal(expectedUserNameField.name, 'name');
 
-  let expectedUserAddressField = expectedUserField.selectionSet[2];
+  let expectedUserAddressField = expectedUserField.selectionSet.toArray()[2];
   assert.equal(expectedUserAddressField instanceof Type.Field, true);
   assert.equal(expectedUserAddressField.name, 'address');
 
-  let expectedUserAddressIdField = expectedUserAddressField.selectionSet[0];
+  let expectedUserAddressIdField = expectedUserAddressField.selectionSet.toArray()[0];
   assert.equal(expectedUserAddressIdField instanceof Type.Field, true);
   assert.equal(expectedUserAddressIdField.name, 'id');
 
-  let expectedUserAddressCityField = expectedUserAddressField.selectionSet[1];
+  let expectedUserAddressCityField = expectedUserAddressField.selectionSet.toArray()[1];
   assert.equal(expectedUserAddressCityField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCityField.name, 'city');
 
-  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet[2];
+  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet.toArray()[2];
   assert.equal(expectedUserAddressCountryField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCountryField.name, 'country');
 });
 
 test('reflexive relationships', function(assert) {
-  let rootField = nodeParseTree.selectionSet[0];
-  let nodeSelectionSet = rootField.selectionSet;
+  let rootField = nodeParseTree.selectionSet.toArray()[0];
+  let nodeSelectionSet = rootField.selectionSet.toArray();
 
   let expectedIdField = nodeSelectionSet[0];
   assert.equal(expectedIdField instanceof Type.Field, true);
@@ -171,11 +171,11 @@ test('reflexive relationships', function(assert) {
   assert.equal(expectedParentField instanceof Type.Field, true);
   assert.equal(expectedParentField.name, 'parent');
 
-  let expectedParentIdField = expectedParentField.selectionSet[0];
+  let expectedParentIdField = expectedParentField.selectionSet.toArray()[0];
   assert.equal(expectedParentIdField instanceof Type.Field, true);
   assert.equal(expectedParentIdField.name, 'id');
 
-  let expectedParentNameField = expectedParentField.selectionSet[1];
+  let expectedParentNameField = expectedParentField.selectionSet.toArray()[1];
   assert.equal(expectedParentNameField instanceof Type.Field, true);
   assert.equal(expectedParentNameField.name, 'name');
 
@@ -183,11 +183,11 @@ test('reflexive relationships', function(assert) {
   assert.equal(expectedChildrenField instanceof Type.Field, true);
   assert.equal(expectedChildrenField.name, 'children');
 
-  let expectedChildrenIdField = expectedChildrenField.selectionSet[0];
+  let expectedChildrenIdField = expectedChildrenField.selectionSet.toArray()[0];
   assert.equal(expectedChildrenIdField instanceof Type.Field, true);
   assert.equal(expectedChildrenIdField.name, 'id');
 
-  let expectedChildrenNameField = expectedChildrenField.selectionSet[1];
+  let expectedChildrenNameField = expectedChildrenField.selectionSet.toArray()[1];
   assert.equal(expectedChildrenNameField instanceof Type.Field, true);
   assert.equal(expectedChildrenNameField.name, 'name');
 });

--- a/tests/unit/parser-test.js
+++ b/tests/unit/parser-test.js
@@ -62,132 +62,132 @@ test('makes the root of the tree an Operation', function(assert) {
 
   let rootSelectionSet = projectsParseTree.selectionSet;
   assert.equal(rootSelectionSet instanceof Type.SelectionSet, true);
-  assert.equal(rootSelectionSet.toArray().length, 1);
+  assert.equal(rootSelectionSet.length, 1);
 });
 
 test('root field is generated in the selection set', function(assert){
-  let rootField = projectsParseTree.selectionSet.toArray()[0];
+  let rootField = projectsParseTree.selectionSet.get(0);
   assert.equal(rootField instanceof Type.Field, true);
   assert.equal(rootField.name, 'projects');
 });
 
 test('there are as many elements in the selection set as there are top level fields (plus the id field)', function(assert){
-  let rootField = projectsParseTree.selectionSet.toArray()[0];
+  let rootField = projectsParseTree.selectionSet.get(0);
   let projectsSelectionSet = rootField.selectionSet;
 
-  assert.equal(projectsSelectionSet.toArray().length, 4);
+  assert.equal(projectsSelectionSet.length, 4);
 });
 
 test('nested fields are generated in the root field selection set', function(assert){
-  let rootField = projectsParseTree.selectionSet.toArray()[0];
-  let projectsSelectionSet = rootField.selectionSet.toArray();
+  let rootField = projectsParseTree.selectionSet.get(0);
+  let projectsSelectionSet = rootField.selectionSet;
 
-  let expectedIdField = projectsSelectionSet[0];
+  let expectedIdField = projectsSelectionSet.get(0);
   assert.equal(expectedIdField instanceof Type.Field, true);
   assert.equal(expectedIdField.name, 'id');
 
-  let expectedStatusField = projectsSelectionSet[1];
+  let expectedStatusField = projectsSelectionSet.get(1);
   assert.equal(expectedStatusField instanceof Type.Field, true);
   assert.equal(expectedStatusField.name, 'status');
 
-  let expectedNameField = projectsSelectionSet[2];
+  let expectedNameField = projectsSelectionSet.get(2);
   assert.equal(expectedNameField instanceof Type.Field, true);
   assert.equal(expectedNameField.name, 'name');
 
-  let expectedUserField = projectsSelectionSet[3];
+  let expectedUserField = projectsSelectionSet.get(3);
   assert.equal(expectedUserField instanceof Type.Field, true);
   assert.equal(expectedUserField.name, 'user');
 
-  let expectedUserIdField = expectedUserField.selectionSet.toArray()[0];
+  let expectedUserIdField = expectedUserField.selectionSet.get(0);
   assert.equal(expectedUserIdField instanceof Type.Field, true);
   assert.equal(expectedUserIdField.name, 'id');
 
-  let expectedUserNameField = expectedUserField.selectionSet.toArray()[1];
+  let expectedUserNameField = expectedUserField.selectionSet.get(1);
   assert.equal(expectedUserNameField instanceof Type.Field, true);
   assert.equal(expectedUserNameField.name, 'name');
 
-  let expectedUserAddressField = expectedUserField.selectionSet.toArray()[2];
+  let expectedUserAddressField = expectedUserField.selectionSet.get(2);
   assert.equal(expectedUserAddressField instanceof Type.Field, true);
   assert.equal(expectedUserAddressField.name, 'address');
 
-  let expectedUserAddressIdField = expectedUserAddressField.selectionSet.toArray()[0];
+  let expectedUserAddressIdField = expectedUserAddressField.selectionSet.get(0);
   assert.equal(expectedUserAddressIdField instanceof Type.Field, true);
   assert.equal(expectedUserAddressIdField.name, 'id');
 
-  let expectedUserAddressCityField = expectedUserAddressField.selectionSet.toArray()[1];
+  let expectedUserAddressCityField = expectedUserAddressField.selectionSet.get(1);
   assert.equal(expectedUserAddressCityField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCityField.name, 'city');
 
-  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet.toArray()[2];
+  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet.get(2);
   assert.equal(expectedUserAddressCountryField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCountryField.name, 'country');
 });
 
 test('belongsTo id injection', function(assert) {
-  let rootField = projectsParseTree.selectionSet.toArray()[0];
-  let projectsSelectionSet = rootField.selectionSet.toArray();
-  let expectedUserField = projectsSelectionSet[3];
+  let rootField = projectsParseTree.selectionSet.get(0);
+  let projectsSelectionSet = rootField.selectionSet;
+  let expectedUserField = projectsSelectionSet.get(3);
 
-  assert.equal(expectedUserField.selectionSet.toArray().length, 3);
+  assert.equal(expectedUserField.selectionSet.length, 3);
 
-  let expectedUserIdField = expectedUserField.selectionSet.toArray()[0];
+  let expectedUserIdField = expectedUserField.selectionSet.get(0);
   assert.equal(expectedUserIdField instanceof Type.Field, true);
   assert.equal(expectedUserIdField.name, 'id');
 
-  let expectedUserNameField = expectedUserField.selectionSet.toArray()[1];
+  let expectedUserNameField = expectedUserField.selectionSet.get(1);
   assert.equal(expectedUserNameField instanceof Type.Field, true);
   assert.equal(expectedUserNameField.name, 'name');
 
-  let expectedUserAddressField = expectedUserField.selectionSet.toArray()[2];
+  let expectedUserAddressField = expectedUserField.selectionSet.get(2);
   assert.equal(expectedUserAddressField instanceof Type.Field, true);
   assert.equal(expectedUserAddressField.name, 'address');
 
-  let expectedUserAddressIdField = expectedUserAddressField.selectionSet.toArray()[0];
+  let expectedUserAddressIdField = expectedUserAddressField.selectionSet.get(0);
   assert.equal(expectedUserAddressIdField instanceof Type.Field, true);
   assert.equal(expectedUserAddressIdField.name, 'id');
 
-  let expectedUserAddressCityField = expectedUserAddressField.selectionSet.toArray()[1];
+  let expectedUserAddressCityField = expectedUserAddressField.selectionSet.get(1);
   assert.equal(expectedUserAddressCityField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCityField.name, 'city');
 
-  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet.toArray()[2];
+  let expectedUserAddressCountryField = expectedUserAddressField.selectionSet.get(2);
   assert.equal(expectedUserAddressCountryField instanceof Type.Field, true);
   assert.equal(expectedUserAddressCountryField.name, 'country');
 });
 
 test('reflexive relationships', function(assert) {
-  let rootField = nodeParseTree.selectionSet.toArray()[0];
-  let nodeSelectionSet = rootField.selectionSet.toArray();
+  let rootField = nodeParseTree.selectionSet.get(0);
+  let nodeSelectionSet = rootField.selectionSet;
 
-  let expectedIdField = nodeSelectionSet[0];
+  let expectedIdField = nodeSelectionSet.get(0);
   assert.equal(expectedIdField instanceof Type.Field, true);
   assert.equal(expectedIdField.name, 'id');
 
-  let expectedNameField = nodeSelectionSet[1];
+  let expectedNameField = nodeSelectionSet.get(1);
   assert.equal(expectedNameField instanceof Type.Field, true);
   assert.equal(expectedNameField.name, 'name');
 
-  let expectedParentField = nodeSelectionSet[2];
+  let expectedParentField = nodeSelectionSet.get(2);
   assert.equal(expectedParentField instanceof Type.Field, true);
   assert.equal(expectedParentField.name, 'parent');
 
-  let expectedParentIdField = expectedParentField.selectionSet.toArray()[0];
+  let expectedParentIdField = expectedParentField.selectionSet.get(0);
   assert.equal(expectedParentIdField instanceof Type.Field, true);
   assert.equal(expectedParentIdField.name, 'id');
 
-  let expectedParentNameField = expectedParentField.selectionSet.toArray()[1];
+  let expectedParentNameField = expectedParentField.selectionSet.get(1);
   assert.equal(expectedParentNameField instanceof Type.Field, true);
   assert.equal(expectedParentNameField.name, 'name');
 
-  let expectedChildrenField = nodeSelectionSet[3];
+  let expectedChildrenField = nodeSelectionSet.get(3);
   assert.equal(expectedChildrenField instanceof Type.Field, true);
   assert.equal(expectedChildrenField.name, 'children');
 
-  let expectedChildrenIdField = expectedChildrenField.selectionSet.toArray()[0];
+  let expectedChildrenIdField = expectedChildrenField.selectionSet.get(0);
   assert.equal(expectedChildrenIdField instanceof Type.Field, true);
   assert.equal(expectedChildrenIdField.name, 'id');
 
-  let expectedChildrenNameField = expectedChildrenField.selectionSet.toArray()[1];
+  let expectedChildrenNameField = expectedChildrenField.selectionSet.get(1);
   assert.equal(expectedChildrenNameField instanceof Type.Field, true);
   assert.equal(expectedChildrenNameField.name, 'name');
 });

--- a/tests/unit/types/argument-set-test.js
+++ b/tests/unit/types/argument-set-test.js
@@ -9,21 +9,21 @@ test("is stack-like", function(assert) {
 
   set.push(3);
 
-  assert.equal(set[0], 1);
-  assert.equal(set[1], 2);
-  assert.equal(set[2], 3);
+  assert.equal(set.toArray()[0], 1);
+  assert.equal(set.toArray()[1], 2);
+  assert.equal(set.toArray()[2], 3);
 
   let popped = set.pop();
 
   assert.equal(popped, 3);
-  assert.equal(set[2], null);
+  assert.equal(set.toArray()[2], null);
 });
 
 test("it can be iterated over", function(assert) {
   let set = new ArgumentSet(1, 2);
   let acc = [];
 
-  set.forEach(function(el){
+  set.toArray().forEach(function(el){
     acc.push(el);
   });
 
@@ -35,53 +35,53 @@ test("it will filter out Arguments with an undefined value", function(assert) {
   let set = new ArgumentSet();
   set.push(new Argument("status", undefined));
 
-  assert.equal(set.length, 0);
+  assert.equal(set.toArray().length, 0);
 });
 
 test("it will not filter out Arguments with a null value", function(assert) {
   let set = new ArgumentSet();
   set.push(new Argument("status", null));
 
-  assert.equal(set.length, 1);
+  assert.equal(set.toArray().length, 1);
 });
 
 
 test("it can be made from a query", function(assert) {
   let set = ArgumentSet.fromQuery({ status: 'active', limit: 10 });
 
-  assert.equal(set.length, 2);
-  assert.equal(set[0].name, 'status');
-  assert.equal(set[0].value, 'active');
-  assert.equal(set[1].name, 'limit');
-  assert.equal(set[1].value, 10);
+  assert.equal(set.toArray().length, 2);
+  assert.equal(set.toArray()[0].name, 'status');
+  assert.equal(set.toArray()[0].value, 'active');
+  assert.equal(set.toArray()[1].name, 'limit');
+  assert.equal(set.toArray()[1].value, 10);
 });
 
 test("does not filter out null arguments from a query", function(assert) {
   let set = ArgumentSet.fromQuery({ status: null, limit: 10 });
 
-  assert.equal(set.length, 2);
-  assert.equal(set[0].name, 'status');
-  assert.equal(set[0].value, null);
-  assert.equal(set[1].name, 'limit');
-  assert.equal(set[1].value, 10);
+  assert.equal(set.toArray().length, 2);
+  assert.equal(set.toArray()[0].name, 'status');
+  assert.equal(set.toArray()[0].value, null);
+  assert.equal(set.toArray()[1].name, 'limit');
+  assert.equal(set.toArray()[1].value, 10);
 });
 
 test("filters out undefined arguments from a query", function(assert) {
   let set = ArgumentSet.fromQuery({ status: undefined, limit: 10 });
 
-  assert.equal(set.length, 1);
-  assert.equal(set[0].name, 'limit');
-  assert.equal(set[0].value, 10);
+  assert.equal(set.toArray().length, 1);
+  assert.equal(set.toArray()[0].name, 'limit');
+  assert.equal(set.toArray()[0].value, 10);
 });
 
 test("it can be made from a nested query", function(assert) {
   let set = ArgumentSet.fromQuery({ project: { id: 1 }, limit: 10 });
 
-  assert.equal(set.length, 2);
-  assert.equal(set[0].name, 'project');
-  assert.equal(set[0].value instanceof ArgumentSet, true);
-  assert.equal(set[0].value[0].name, 'id');
-  assert.equal(set[0].value[0].value, 1);
-  assert.equal(set[1].name, 'limit');
-  assert.equal(set[1].value, 10);
+  assert.equal(set.toArray().length, 2);
+  assert.equal(set.toArray()[0].name, 'project');
+  assert.equal(set.toArray()[0].value instanceof ArgumentSet, true);
+  assert.equal(set.toArray()[0].value.toArray()[0].name, 'id');
+  assert.equal(set.toArray()[0].value.toArray()[0].value, 1);
+  assert.equal(set.toArray()[1].name, 'limit');
+  assert.equal(set.toArray()[1].value, 10);
 });

--- a/tests/unit/types/argument-set-test.js
+++ b/tests/unit/types/argument-set-test.js
@@ -9,14 +9,14 @@ test("is stack-like", function(assert) {
 
   set.push(3);
 
-  assert.equal(set.toArray()[0], 1);
-  assert.equal(set.toArray()[1], 2);
-  assert.equal(set.toArray()[2], 3);
+  assert.equal(set.get(0), 1);
+  assert.equal(set.get(1), 2);
+  assert.equal(set.get(2), 3);
 
   let popped = set.pop();
 
   assert.equal(popped, 3);
-  assert.equal(set.toArray()[2], null);
+  assert.equal(set.get(2), null);
 });
 
 test("it can be iterated over", function(assert) {
@@ -35,53 +35,53 @@ test("it will filter out Arguments with an undefined value", function(assert) {
   let set = new ArgumentSet();
   set.push(new Argument("status", undefined));
 
-  assert.equal(set.toArray().length, 0);
+  assert.equal(set.length, 0);
 });
 
 test("it will not filter out Arguments with a null value", function(assert) {
   let set = new ArgumentSet();
   set.push(new Argument("status", null));
 
-  assert.equal(set.toArray().length, 1);
+  assert.equal(set.length, 1);
 });
 
 
 test("it can be made from a query", function(assert) {
   let set = ArgumentSet.fromQuery({ status: 'active', limit: 10 });
 
-  assert.equal(set.toArray().length, 2);
-  assert.equal(set.toArray()[0].name, 'status');
-  assert.equal(set.toArray()[0].value, 'active');
-  assert.equal(set.toArray()[1].name, 'limit');
-  assert.equal(set.toArray()[1].value, 10);
+  assert.equal(set.length, 2);
+  assert.equal(set.get(0).name, 'status');
+  assert.equal(set.get(0).value, 'active');
+  assert.equal(set.get(1).name, 'limit');
+  assert.equal(set.get(1).value, 10);
 });
 
 test("does not filter out null arguments from a query", function(assert) {
   let set = ArgumentSet.fromQuery({ status: null, limit: 10 });
 
-  assert.equal(set.toArray().length, 2);
-  assert.equal(set.toArray()[0].name, 'status');
-  assert.equal(set.toArray()[0].value, null);
-  assert.equal(set.toArray()[1].name, 'limit');
-  assert.equal(set.toArray()[1].value, 10);
+  assert.equal(set.length, 2);
+  assert.equal(set.get(0).name, 'status');
+  assert.equal(set.get(0).value, null);
+  assert.equal(set.get(1).name, 'limit');
+  assert.equal(set.get(1).value, 10);
 });
 
 test("filters out undefined arguments from a query", function(assert) {
   let set = ArgumentSet.fromQuery({ status: undefined, limit: 10 });
 
-  assert.equal(set.toArray().length, 1);
-  assert.equal(set.toArray()[0].name, 'limit');
-  assert.equal(set.toArray()[0].value, 10);
+  assert.equal(set.length, 1);
+  assert.equal(set.get(0).name, 'limit');
+  assert.equal(set.get(0).value, 10);
 });
 
 test("it can be made from a nested query", function(assert) {
   let set = ArgumentSet.fromQuery({ project: { id: 1 }, limit: 10 });
 
-  assert.equal(set.toArray().length, 2);
-  assert.equal(set.toArray()[0].name, 'project');
-  assert.equal(set.toArray()[0].value instanceof ArgumentSet, true);
-  assert.equal(set.toArray()[0].value.toArray()[0].name, 'id');
-  assert.equal(set.toArray()[0].value.toArray()[0].value, 1);
-  assert.equal(set.toArray()[1].name, 'limit');
-  assert.equal(set.toArray()[1].value, 10);
+  assert.equal(set.length, 2);
+  assert.equal(set.get(0).name, 'project');
+  assert.equal(set.get(0).value instanceof ArgumentSet, true);
+  assert.equal(set.get(0).value.get(0).name, 'id');
+  assert.equal(set.get(0).value.get(0).value, 1);
+  assert.equal(set.get(1).name, 'limit');
+  assert.equal(set.get(1).value, 10);
 });

--- a/tests/unit/types/argument-test.js
+++ b/tests/unit/types/argument-test.js
@@ -9,3 +9,16 @@ test('can be constructed', function(assert){
   assert.equal(argument.name, 'theName');
   assert.equal(argument.value, 'theValue');
 });
+
+test('can be set piecewise', function(assert){
+  let argument = new Argument();
+
+  assert.notOk(argument.name);
+  assert.notOk(argument.value);
+
+  argument.name = 'theName';
+  assert.equal(argument.name, 'theName');
+
+  argument.value = 'theValue';
+  assert.equal(argument.value, 'theValue');
+});

--- a/tests/unit/types/field-test.js
+++ b/tests/unit/types/field-test.js
@@ -21,8 +21,8 @@ test('if no argument or selection sets are provided, they default to new empty s
   assert.equal(field.alias, null);
 
   assert.equal(field.argumentSet instanceof ArgumentSet, true);
-  assert.equal(field.argumentSet.length, 0);
+  assert.equal(field.argumentSet.toArray().length, 0);
 
   assert.equal(field.selectionSet instanceof SelectionSet, true);
-  assert.equal(field.selectionSet.length, 0);
+  assert.equal(field.selectionSet.toArray().length, 0);
 });

--- a/tests/unit/types/field-test.js
+++ b/tests/unit/types/field-test.js
@@ -21,8 +21,8 @@ test('if no argument or selection sets are provided, they default to new empty s
   assert.equal(field.alias, null);
 
   assert.equal(field.argumentSet instanceof ArgumentSet, true);
-  assert.equal(field.argumentSet.toArray().length, 0);
+  assert.equal(field.argumentSet.length, 0);
 
   assert.equal(field.selectionSet instanceof SelectionSet, true);
-  assert.equal(field.selectionSet.toArray().length, 0);
+  assert.equal(field.selectionSet.length, 0);
 });

--- a/tests/unit/types/selection-set-test.js
+++ b/tests/unit/types/selection-set-test.js
@@ -8,21 +8,21 @@ test("is stack-like", function(assert) {
 
   set.push(3);
 
-  assert.equal(set[0], 1);
-  assert.equal(set[1], 2);
-  assert.equal(set[2], 3);
+  assert.equal(set.toArray()[0], 1);
+  assert.equal(set.toArray()[1], 2);
+  assert.equal(set.toArray()[2], 3);
 
   let popped = set.pop();
 
   assert.equal(popped, 3);
-  assert.equal(set[2], null);
+  assert.equal(set.toArray()[2], null);
 });
 
 test("it can be iterated over", function(assert) {
   let set = new SelectionSet(1, 2);
   let acc = [];
 
-  set.forEach(function(el){
+  set.toArray().forEach(function(el){
     acc.push(el);
   });
 

--- a/tests/unit/types/selection-set-test.js
+++ b/tests/unit/types/selection-set-test.js
@@ -8,14 +8,14 @@ test("is stack-like", function(assert) {
 
   set.push(3);
 
-  assert.equal(set.toArray()[0], 1);
-  assert.equal(set.toArray()[1], 2);
-  assert.equal(set.toArray()[2], 3);
+  assert.equal(set.get(0), 1);
+  assert.equal(set.get(1), 2);
+  assert.equal(set.get(2), 3);
 
   let popped = set.pop();
 
   assert.equal(popped, 3);
-  assert.equal(set.toArray()[2], null);
+  assert.equal(set.get(2), null);
 });
 
 test("it can be iterated over", function(assert) {


### PR DESCRIPTION
Instead of extending the native class Array, provide a `toArray()` method which returns a real instance of an Array for the caller to do as they see fit.