### PR TITLE
Generate correct string for object arrays

### DIFF
--- a/addon/generator.js
+++ b/addon/generator.js
@@ -62,8 +62,20 @@ export default {
   },
 
   wrapArrayInStringTokens(array) {
-    return array.map((ele) => {
-      return this.wrapInStringTokens(ele);
+    return array.map(ele => {
+      if (typeof ele === 'object') {
+        let generatedElements = [];
+        let eleKeys = Object.keys(ele);
+
+        eleKeys.forEach(key => {
+          let generatedValue = this.generateArgument({ name: key, value: ele[key] });
+          generatedElements.push(generatedValue);
+        });
+
+        return this.argumentObjectOpeningToken + generatedElements.join(', ') + this.argumentObjectClosingToken;
+      } else {
+        return this.wrapInStringTokens(ele);
+      }
     }).join();
   },
 

--- a/tests/unit/generator-test.js
+++ b/tests/unit/generator-test.js
@@ -19,7 +19,8 @@ test('all the things', function(assert) {
     new Type.Argument('status', 'active'),
     new Type.Argument('embedded', new Type.ArgumentSet(new Type.Argument('id', 1))),
     new Type.Argument('limit', 10),
-    new Type.Argument('offset', 0)
+    new Type.Argument('offset', 0),
+    new Type.Argument('objectArray', [{ foo: 'bar', bar: 'foo' }])
   );
   let post = new Type.Field('post', 'postAlias', postArgumentSet, postSelectionSet);
 
@@ -27,5 +28,8 @@ test('all the things', function(assert) {
   let operationArgumentSet = new Type.ArgumentSet();
   let operation = new Type.Operation('query', 'postsQuery', operationArgumentSet, operationSelectionSet);
 
-  assert.equal(Generator.generate(operation), `query postsQuery { postAlias: post(ids: ["1","2","3"], status: "active", embedded: { id: 1 }, limit: 10, offset: 0) { id status author { id username } } }`);
+  assert.equal(
+    Generator.generate(operation),
+    `query postsQuery { postAlias: post(ids: ["1","2","3"], status: "active", embedded: { id: 1 }, limit: 10, offset: 0, objectArray: [{ foo: "bar", bar: "foo" }]) { id status author { id username } } }`
+  );
 });


### PR DESCRIPTION
**Problem**: when mutating with embedded records, arrays of objects were not being serialised correctly, appearing as `modelName: "[object Object]"` in the request string. This was due to all array elements being wrapped in string tokens in the `wrapArrayInStringTokens` method in `generator.js`.

**Solution**: for each object in an array, generate arguments for each key-value pair. This allows the building of a string in the form `modelName: [{ key: "value" }]` that can be passed back as part of the request, only wrapping object values in the string tokens instead of the entire object.