### PR TITLE
Update adapter ajax function to reject when response contains errors

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -269,7 +269,19 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   ajax: function(url, options) {
-    return request(url, options);
+    let adapter = this;
+
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      return request(url, options).then(response => {
+        const adapterResponse = adapter.handleResponse(null, null, response);
+
+        if (response && adapterResponse.isAdapterError) {
+          Ember.run.join(null, reject, response);
+        } else {
+          Ember.run.join(null, resolve, response);
+        }
+      });
+    });
   },
 
   /**


### PR DESCRIPTION
After https://github.com/alphasights/ember-graphql-adapter/commit/a3e45184185811f52696b578578d1ebe81995c19, we no longer rejected the promise from an ajax request when receiving a response with status 200 but an `errors` key in the response. This caused problems further along when Ember tried interpreting `null` as an actual record.