### PR TITLE
Fix incoherent usage of ember-inflector

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -2,6 +2,7 @@ import DS from 'ember-data';
 import Ember from 'ember';
 import Compiler from './compiler';
 import request from 'ember-ajax/request';
+import { pluralize } from 'ember-inflector';
 
 export default DS.Adapter.extend({
   endpoint: null,
@@ -59,7 +60,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   findAll: function(store, type) {
-    let operationName = this.normalizeCase(Ember.String.pluralize(type.modelName));
+    let operationName = this.normalizeCase(pluralize(type.modelName));
 
     return this.request(store, type, {
       'operationName': operationName,
@@ -87,7 +88,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   query: function(store, type, query) {
-    let operationName = this.normalizeCase(Ember.String.pluralize(type.modelName));
+    let operationName = this.normalizeCase(pluralize(type.modelName));
 
     return this.request(store, type, {
       'operationName': operationName,
@@ -137,7 +138,7 @@ export default DS.Adapter.extend({
     @return {Promise} promise
   */
   findMany(store, type, ids) {
-    let operationName = this.normalizeCase(Ember.String.pluralize(type.modelName));
+    let operationName = this.normalizeCase(pluralize(type.modelName));
 
     return this.request(store, type, {
       'operationName': operationName,

--- a/addon/parser.js
+++ b/addon/parser.js
@@ -1,5 +1,5 @@
 import * as Type from 'ember-graphql-adapter/types';
-import Ember from 'ember';
+import { singularize } from 'ember-inflector';
 
 class Parser {
   constructor({normalizeCaseFn, parseSelectionSet}) {
@@ -66,7 +66,7 @@ class Parser {
 
   _buildAsyncRelationship(relName, { kind }) {
     let suffix = kind === 'hasMany' ? 'Ids' : 'Id';
-    return this._buildField(Ember.String.singularize(relName) + suffix);
+    return this._buildField(singularize(relName) + suffix);
   }
 }
 

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,13 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
+import { pluralize, singularize } from 'ember-inflector';
 
-const {
-  String: {
-    camelize,
-    pluralize,
-    singularize
-  }
-} = Ember;
+const { String: { camelize } } = Ember;
 
 export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   isNewSerializerAPI: true,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-data": "~2.16.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-inflector": "^2.1.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,6 +2319,12 @@ ember-inflector@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
+ember-inflector@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.1.0.tgz#afcb92d022a4eab58f08ff4578eafc3a1de2d09b"
+  dependencies:
+    ember-cli-babel "^6.0.0"
+
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"


### PR DESCRIPTION
### Problem
We're using ember-inflector incorrectly in two [deprecated](https://github.com/emberjs/ember-inflector/pull/131) ways:
- via `Ember.Inflector`
- via `Ember.String.singularize` and `Ember.String.pluralize`

and `ember-inflector` is not even listed as a dependency.

### Solution
- Declares `ember-inflector` as an explicit dependency.
- Fixes usage of `singularize` and `pluralize`.
- Fixes usage of `Ember.Inflector` as prescribed in the [ember guides](https://guides.emberjs.com/v2.16.0/models/customizing-adapters/#toc_pluralization-customization)