### PR TITLE
Migrate to new ember modules api

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -1,5 +1,9 @@
+import { get } from '@ember/object';
+import $ from 'jquery';
+import { join } from '@ember/runloop';
+import { Promise as EmberPromise } from 'rsvp';
+import { camelize } from '@ember/string';
 import DS from 'ember-data';
-import Ember from 'ember';
 import Compiler from './compiler';
 import request from 'ember-ajax/request';
 import { pluralize } from 'ember-inflector';
@@ -19,7 +23,7 @@ export default DS.Adapter.extend({
     @return {String} string
   */
   normalizeCase: function(string) {
-    return Ember.String.camelize(string);
+    return camelize(string);
   },
 
   /**
@@ -272,17 +276,17 @@ export default DS.Adapter.extend({
   ajax: function(url, options) {
     let adapter = this;
 
-    return new Ember.RSVP.Promise((resolve, reject) => {
+    return new EmberPromise((resolve, reject) => {
       return request(url, options).then(response => {
         const adapterResponse = adapter.handleResponse(null, null, response);
 
         if (response && adapterResponse.isAdapterError) {
-          Ember.run.join(null, reject, response);
+          join(null, reject, response);
         } else {
-          Ember.run.join(null, resolve, response);
+          join(null, resolve, response);
         }
       }, error => {
-        Ember.run.join(null, reject, error);
+        join(null, reject, error);
       });
     });
   },
@@ -297,7 +301,7 @@ export default DS.Adapter.extend({
     var json = responseText;
 
     try {
-      json = Ember.$.parseJSON(responseText);
+      json = $.parseJSON(responseText);
     } catch (e) {
       // empty
     }
@@ -319,7 +323,7 @@ export default DS.Adapter.extend({
       'context': this
     };
 
-    let headers = Ember.get(this, 'headers');
+    let headers = get(this, 'headers');
     if (headers !== undefined) {
       opts.beforeSend = function (xhr) {
         Object.keys(headers).forEach((key) =>  xhr.setRequestHeader(key, headers[key]));

--- a/addon/generator.js
+++ b/addon/generator.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { typeOf } from '@ember/utils';
 
 export default {
   openingToken: ' {',
@@ -50,11 +50,11 @@ export default {
   },
 
   generateArgument({name, value}) {
-    if (Ember.typeOf(value) === 'string') {
+    if (typeOf(value) === 'string') {
       value = this.wrapInStringTokens(value);
-    } else if (Ember.typeOf(value) === 'array') {
+    } else if (typeOf(value) === 'array') {
       value = this.argumentArrayOpeningToken + this.wrapArrayInStringTokens(value) + this.argumentArrayClosingToken;
-    } else if (Ember.typeOf(value) === 'object') {
+    } else if (typeOf(value) === 'object') {
       value = this.argumentObjectOpeningToken + this.generateArgumentSet(value) + this.argumentObjectClosingToken;
     }
 

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,8 +1,9 @@
+import { assert } from '@ember/debug';
+import { isNone, typeOf } from '@ember/utils';
+import { get } from '@ember/object';
+import { camelize } from '@ember/string';
 import DS from 'ember-data';
-import Ember from 'ember';
 import { pluralize, singularize } from 'ember-inflector';
-
-const { String: { camelize } } = Ember;
 
 export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   isNewSerializerAPI: true,
@@ -13,7 +14,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
 
   serializeIntoHash(hash, typeClass, snapshot, options) {
     if (snapshot.id) {
-      hash[Ember.get(this, 'primaryKey')] = snapshot.id;
+      hash[get(this, 'primaryKey')] = snapshot.id;
     }
     this._super(hash, typeClass, snapshot, options);
   },
@@ -25,7 +26,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
       let value = snapshot.attr(key);
       if (type) {
         if (type === 'string') {
-          if (!Ember.isNone(value)) {
+          if (!isNone(value)) {
             value = value.replace(/\\/g, '\\\\');
             value = value.replace(/\"/g, '\\"'); //eslint-disable-line no-useless-escape
           }
@@ -82,11 +83,11 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
 
     const type = this.normalizeCase(primaryModelClass.modelName);
     let root = data[type];
-    if (Ember.typeOf(root) === 'undefined') {
+    if (typeOf(root) === 'undefined') {
       root = data[pluralize(type)];
     }
 
-    Ember.assert('The root of the result must be the model class name or the plural model class name', Ember.typeOf(root) !== 'undefined');
+    assert('The root of the result must be the model class name or the plural model class name', typeOf(root) !== 'undefined');
 
     if (meta) { root['meta'] = meta; }
 
@@ -106,7 +107,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
         if (kind === 'belongsTo') {
           data = this.extractRelationship(type, relationshipHash);
         } else if (kind === 'hasMany') {
-          if (!Ember.isNone(relationshipHash)) {
+          if (!isNone(relationshipHash)) {
             data = new Array(relationshipHash.length);
             for (let i = 0, l = relationshipHash.length; i < l; i++) {
               let item = relationshipHash[i];

--- a/addon/types/argument-set.js
+++ b/addon/types/argument-set.js
@@ -1,7 +1,5 @@
+import { typeOf } from '@ember/utils';
 import { Argument } from '../types';
-import Ember from 'ember';
-
-const { typeOf } = Ember;
 
 export default class ArgumentSet {
   constructor(...args) {

--- a/tests/helpers/owner.js
+++ b/tests/helpers/owner.js
@@ -1,11 +1,12 @@
+import EmberObject from '@ember/object';
 import Ember from 'ember';
 
 let Owner;
 
 if (Ember._RegistryProxyMixin && Ember._ContainerProxyMixin) {
-  Owner = Ember.Object.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
+  Owner = EmberObject.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
 } else {
-  Owner = Ember.Object.extend();
+  Owner = EmberObject.extend();
 }
 
 export default Owner;

--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -1,3 +1,4 @@
+import { dasherize } from '@ember/string';
 import Ember from 'ember';
 import DS from 'ember-data';
 import { Adapter, Serializer } from 'ember-graphql-adapter';
@@ -39,7 +40,7 @@ export default function setupStore(options) {
   }
 
   for (var prop in options) {
-    registry.register('model:' + Ember.String.dasherize(prop), options[prop]);
+    registry.register('model:' + dasherize(prop), options[prop]);
   }
 
   registry.register('service:store', DS.Store.extend({

--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -1,12 +1,14 @@
+import { underscore } from '@ember/string';
+import { copy } from '@ember/object/internals';
+import RSVP from 'rsvp';
+import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
-import Ember from 'ember';
 import DS from 'ember-data';
-import {module, test} from 'qunit';
-import {Adapter, Serializer} from 'ember-graphql-adapter';
+import { module, test } from 'qunit';
+import { Adapter, Serializer } from 'ember-graphql-adapter';
 
 var env, store, adapter;
 var passedUrl, passedQuery;
-var run = Ember.run;
 var Author, Profile, Post, Comment, PostCategory;
 
 module("integration/adapter - GraphQL adapter", {
@@ -54,7 +56,7 @@ function ajaxResponse(value) {
     passedUrl = url;
     passedQuery = data.query;
 
-    return run(Ember.RSVP, 'resolve', Ember.copy(value, true));
+    return run(RSVP, 'resolve', copy(value, true));
   };
 }
 
@@ -495,7 +497,7 @@ test('Resources and attributes with multiple words are snake cased in times of n
   assert.expect(5);
 
   let normalizeCaseFn = function(name) {
-    return Ember.String.underscore(name);
+    return underscore(name);
   };
 
   adapter.normalizeCase = normalizeCaseFn;
@@ -534,7 +536,7 @@ test('Mutation names can be snake cased too', function(assert) {
   assert.expect(4);
 
   let normalizeCaseFn = function(name) {
-    return Ember.String.underscore(name);
+    return underscore(name);
   };
 
   adapter.normalizeCase = normalizeCaseFn;

--- a/tests/integration/serializer-test.js
+++ b/tests/integration/serializer-test.js
@@ -1,9 +1,8 @@
+import { run } from '@ember/runloop';
 import setupStore from 'dummy/tests/helpers/store';
-import Ember from 'ember';
 import DS from 'ember-data';
-import {module, test} from 'qunit';
+import { module, test } from 'qunit';
 
-let run = Ember.run;
 let env, store;
 let Address, Blog, Profile, Post, User;
 

--- a/tests/unit/compiler-test.js
+++ b/tests/unit/compiler-test.js
@@ -1,5 +1,5 @@
+import { camelize } from '@ember/string';
 import { test, module } from 'qunit';
-import Ember from 'ember';
 import ModelDouble from '../helpers/model-double';
 import StoreDouble from '../helpers/store-double';
 import Compiler from 'ember-graphql-adapter/compiler';
@@ -7,7 +7,7 @@ import Compiler from 'ember-graphql-adapter/compiler';
 module('unit:ember-graphql-adapter/compiler');
 
 const normalizeCaseFn = function(string) {
-  return Ember.String.camelize(string);
+  return camelize(string);
 };
 
 test("takes an Model and responds with GraphQL query", function(assert) {

--- a/tests/unit/parser-test.js
+++ b/tests/unit/parser-test.js
@@ -1,5 +1,5 @@
+import { camelize } from '@ember/string';
 import { test, module } from 'qunit';
-import Ember from 'ember';
 import Parser from 'ember-graphql-adapter/parser';
 import * as Type from 'ember-graphql-adapter/types';
 import ArgumentSet from 'ember-graphql-adapter/types/argument-set';
@@ -7,7 +7,7 @@ import ModelDouble from '../helpers/model-double';
 import StoreDouble from '../helpers/store-double';
 
 const normalizeCaseFn = function(string) {
-  return Ember.String.camelize(string);
+  return camelize(string);
 };
 
 let nodeParseTree, projectsParseTree;


### PR DESCRIPTION
## What this does

Used the CLI utility `ember-modules-codemod` to migrate the app as per the instructions on the [ember 2.16 release blog post](https://www.emberjs.com/blog/2017/10/11/ember-2-16-released.html#toc_updating-your-application).