### PR TITLE
Use fromQuery method to build argumentset for objects

### DIFF
--- a/addon/generator.js
+++ b/addon/generator.js
@@ -1,4 +1,5 @@
 import { typeOf } from '@ember/utils';
+import ArgumentSet from 'ember-graphql-adapter/types/argument-set';
 
 export default {
   openingToken: ' {',
@@ -55,6 +56,7 @@ export default {
     } else if (typeOf(value) === 'array') {
       value = this.argumentArrayOpeningToken + this.wrapArrayInStringTokens(value) + this.argumentArrayClosingToken;
     } else if (typeOf(value) === 'object') {
+      value = ArgumentSet.fromQuery(value);
       value = this.argumentObjectOpeningToken + this.generateArgumentSet(value) + this.argumentObjectClosingToken;
     }
 

--- a/addon/generator.js
+++ b/addon/generator.js
@@ -1,5 +1,6 @@
 import { typeOf } from '@ember/utils';
 import ArgumentSet from 'ember-graphql-adapter/types/argument-set';
+import SelectionSet from 'ember-graphql-adapter/types/selection-set';
 
 export default {
   openingToken: ' {',
@@ -55,8 +56,11 @@ export default {
       value = this.wrapInStringTokens(value);
     } else if (typeOf(value) === 'array') {
       value = this.argumentArrayOpeningToken + this.wrapArrayInStringTokens(value) + this.argumentArrayClosingToken;
+    } else if (value instanceof SelectionSet || value instanceof ArgumentSet) {
+      value = this.argumentObjectOpeningToken + this.generateArgumentSet(value) + this.argumentObjectClosingToken;
     } else if (typeOf(value) === 'object') {
       value = ArgumentSet.fromQuery(value);
+
       value = this.argumentObjectOpeningToken + this.generateArgumentSet(value) + this.argumentObjectClosingToken;
     }
 

--- a/tests/unit/generator-test.js
+++ b/tests/unit/generator-test.js
@@ -5,6 +5,8 @@ import * as Type from 'ember-graphql-adapter/types';
 module('unit:ember-graphql-adapter/generator');
 
 test('all the things', function(assert) {
+  assert.expect(1)
+
   let fieldId = new Type.Field('id');
   let fieldStatus = new Type.Field('status');
 
@@ -20,7 +22,8 @@ test('all the things', function(assert) {
     new Type.Argument('embedded', new Type.ArgumentSet(new Type.Argument('id', 1))),
     new Type.Argument('limit', 10),
     new Type.Argument('offset', 0),
-    new Type.Argument('objectArray', [{ foo: 'bar', bar: 'foo' }])
+    new Type.Argument('objectArray', [{ foo: 'bar', bar: 'foo' }]),
+    new Type.Argument('object', { id: 'hi' })
   );
   let post = new Type.Field('post', 'postAlias', postArgumentSet, postSelectionSet);
 
@@ -30,6 +33,6 @@ test('all the things', function(assert) {
 
   assert.equal(
     Generator.generate(operation),
-    `query postsQuery { postAlias: post(ids: ["1","2","3"], status: "active", embedded: { id: 1 }, limit: 10, offset: 0, objectArray: [{ foo: "bar", bar: "foo" }]) { id status author { id username } } }`
+    `query postsQuery { postAlias: post(ids: ["1","2","3"], status: "active", embedded: { id: 1 }, limit: 10, offset: 0, objectArray: [{ foo: "bar", bar: "foo" }], object: { id: "hi" }) { id status author { id username } } }`
   );
 });


### PR DESCRIPTION
```
else if (typeOf(value) === 'object') {
      value = this.argumentObjectOpeningToken + this.generateArgumentSet(value) + this.argumentObjectClosingToken;
    }
```
When value is an object that is being passing into `generateArgumentSet`, the following error occurs because the method is trying to call `toArray()` on the object:
`set.toArray is not a function` when it's really just expecting it to be a type ArgumentSet or SelectionSet.

What `generateArgumentList` is actually expecting is an `argumentSet`

Paired with: @delkopiso 