### PR TITLE
Avoid parsing error on the server side when querying

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -27,6 +27,31 @@ export default DS.Adapter.extend({
   },
 
   /**
+    Normalizes query parameters to avoid ParseErrors on the server side.
+
+    @method normalizeQuery
+    @param {Object} query
+    @return {Object} normalized query
+  */
+  normalizeQuery: function(query) {
+    let normalizedQuery = {};
+
+    Object.keys(query).forEach((key) => {
+      let value = query[key];
+
+      if (typeof value === 'string') {
+        normalizedQuery[key] = value
+          .replace(/\\/g, '\\\\')
+          .replace(/\"/g, '\\"'); //eslint-disable-line no-useless-escape
+      } else {
+        normalizedQuery[key] = value;
+      }
+    });
+
+    return normalizedQuery;
+  },
+
+  /**
     Called by the store in order to fetch the JSON for a given
     type and ID.
 
@@ -99,7 +124,7 @@ export default DS.Adapter.extend({
       'operationType': 'query',
       'parseSelectionSet': true,
       'rootFieldName': operationName,
-      'rootFieldQuery': query
+      'rootFieldQuery': this.normalizeQuery(query)
     });
   },
 
@@ -128,7 +153,7 @@ export default DS.Adapter.extend({
       'operationType': 'query',
       'parseSelectionSet': true,
       'rootFieldName': operationName,
-      'rootFieldQuery': query
+      'rootFieldQuery': this.normalizeQuery(query)
     });
   },
 

--- a/tests/integration/adapter-test.js
+++ b/tests/integration/adapter-test.js
@@ -642,3 +642,49 @@ test('Saving a record with a backslash in a string attribute', function(assert) 
     });
   });
 });
+
+test('query - querying a record with double quotes in the query', function(assert) {
+  assert.expect(4);
+
+  ajaxResponse({
+    data: {
+      posts: [{
+        id: '1',
+        name: 'Ember.js "rocks"'
+      }]
+    }
+  });
+
+  run(function() {
+    store.query('post', { name: 'Ember.js "rocks"' }).then(function(posts) {
+      assert.equal(passedUrl, '/graph');
+      assert.equal(passedQuery, 'query posts { posts(name: "Ember.js \\"rocks\\"") { id name } }');
+
+      assert.equal(posts.get('length'), 1);
+      assert.equal(posts.get('firstObject.name'), 'Ember.js "rocks"');
+    });
+  });
+});
+
+test('query - querying a record with backslashes in the query', function(assert) {
+  assert.expect(4);
+
+  ajaxResponse({
+    data: {
+      posts: [{
+        id: '1',
+        name: 'Ember.js \\ rocks'
+      }]
+    }
+  });
+
+  run(function() {
+    store.query('post', { name: 'Ember.js \\ rocks' }).then(function(posts) {
+      assert.equal(passedUrl, '/graph');
+      assert.equal(passedQuery, 'query posts { posts(name: "Ember.js \\\\ rocks") { id name } }');
+
+      assert.equal(posts.get('length'), 1);
+      assert.equal(posts.get('firstObject.name'), 'Ember.js \\ rocks');
+    });
+  });
+});


### PR DESCRIPTION
When trying to query records using string parameters, there is a chance the GraphQL query created will have some unescaped characters, causing a parsing error on the server side.