### PR TITLE
Allow explicit relationship resolution

### DIFF
--- a/addon/parser.js
+++ b/addon/parser.js
@@ -36,7 +36,7 @@ class Parser {
             field = this._buildAsyncRelationship(relName, relationship);
           } else {
             let relModel = store.modelFor(type);
-            if (this.visited.indexOf(relName) === -1) {
+            if (this.visited.indexOf(relName) === -1 || options.resolveAlways) {
               field = new Type.Field(
                 this.normalizeCaseFn(relName),
                 null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-graphql-adapter",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "An Ember CLI adapter for GraphQL",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
### Problem
When resolving an ember model object graph, objects that contain relationships that itself contain relationships with the same name do not get resolved.
Example:
```
+-- angle
    +-- id
    +-- title
    +-- details
    +-- angleTeamMemberships
    |   +-- id
    |   +-- name
    |   +-- avatar
    +-- geographies
    |   +-- id
    |   +-- name
    |   +-- code
    +-- angleCompanies
    |   +-- id
    |   +-- alphaCompany
    |   |   +-- id
    |   |   +-- name
    |   +-- aliasCompany
    |   |   +-- id
    |   |   +-- name
    +-- subAngles
	    +-- id
	    +-- title
	    +-- details
	    +-- angleTeamMemberships (missing)
	    |   +-- id
	    |   +-- name
	    |   +-- avatar
	    +-- geographies (missing)
	    |   +-- id
	    |   +-- name
	    |   +-- code
	    +-- angleCompanies (missing)
	        +-- id
	        +-- alphaCompany
	        |   +-- id
	        |   +-- name
	        +-- aliasCompany
	            +-- id
	            +-- name
```
Given the angle object graph above, a sub-angles's relationships (angleTeamMemberships, geographies, angleCompanies) are missing from the response of an angle's graphql query.
### Root problem
The `ember-graphql-adatper` keeps track of `visited` relationships by the relationship name.  If it encounters the same relationship name again, it will not walk down that path when parsing and building the ember object graph.  This results in a generated graphql query with child relationships missing relationships.
### Solution
Extend the options of the ember model definition with `resolveAlways`.  When the parser encounters this option, it will traverse this relationship even if it has already been `visited`.